### PR TITLE
isValidVATNumber is lying when VIES is down

### DIFF
--- a/src/Mpociot/VatCalculator/VatCalculator.php
+++ b/src/Mpociot/VatCalculator/VatCalculator.php
@@ -591,7 +591,7 @@ class VatCalculator
 
                 return $result->valid;
             } catch (SoapFault $e) {
-                return false;
+                throw new VATCheckUnavailableException('The VAT check service is currently unavailable. Please try again later.');
             }
         }
         throw new VATCheckUnavailableException('The VAT check service is currently unavailable. Please try again later.');


### PR DESCRIPTION
The constructor assumes that the WDSL is not cached by PHP. If the VIES service is down then the SoapClient will fail to download the WSDL and the SoapClient is set to false. But when we have a cached copy of the WDSL, the SoapClient will not be set to false and the class assumes everything is good.

This leads to a problem in isValidVATNumber. If the WSDL was cached, we will have a valid SoapClient. It's first when checkVat is called we notice that the service is down. By catching the SoapFault and returning false the class is lying about the VAT number validity.